### PR TITLE
Update credential default login

### DIFF
--- a/cypress/e2e/credentials/addCredentials.cy.ts
+++ b/cypress/e2e/credentials/addCredentials.cy.ts
@@ -14,7 +14,7 @@ describe(
   function () {
     beforeEach(function () {
       cy.login()
-      cy.visit('/multicloud/infrastructure/')
+      cy.visit('/multicloud/infrastructure/credentials')
     })
 
     it(

--- a/cypress/scripts/local-setup.sh
+++ b/cypress/scripts/local-setup.sh
@@ -4,7 +4,8 @@ export BROWSER="chrome"
 export CYPRESS_OC_IDP=`oc whoami`
 export CYPRESS_OPTIONS_HUB_USER=`oc whoami`
 export CYPRESS_token=`oc whoami -t`
-export CYPRESS_CLUSTER_API_URL=`oc get infrastructure cluster -o jsonpath={.status.apiServerURL}`
+export CYPRESS_CLUSTER_API_URL=`oc whoami --show-server`
+export CYPRESS_BASE_URL=`oc whoami --show-console`
 # export CYPRESS_SPOKE_CLUSTER=""
 # export CYPRESS_CLC_OC_IDP=${CYPRESS_CLC_OC_IDP:-"clc-e2e-htpasswd"}
 # export CYPRESS_CLC_RBAC_PASS=${CYPRESS_CLC_RBAC_PASS:-"test-RBAC-4-e2e"}

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -20,23 +20,12 @@ Cypress.Commands.add('login', (user: string = 'kube:admin', password?: string) =
   cy.session(
     user,
     () => {
-      if (process.env.NODE_ENV === 'production' || password) {
-        const baseUrl = Cypress.env('BASE_URL')
-        const username = user || Cypress.env('OPTIONS_HUB_USER')
-        const pass = password || Cypress.env('OPTIONS_HUB_PASSWORD')
-        cy.exec(`oc login ${baseUrl} -u ${username} -p ${pass}`).then(() => {
-          cy.exec('oc whoami -t').then((result) => {
-            cy.setCookie('acm-access-token-cookie', result.stdout)
-            Cypress.env({ token: result.stdout })
-          })
-        })
-      } else {
         // simple auth for local development environments
         cy.exec('oc whoami -t').then((result) => {
           cy.setCookie('acm-access-token-cookie', result.stdout)
+          cy.setCookie('openshift-session-token', result.stdout) // fails on MCE without this
         })
-      }
-      cy.exec('curl --insecure https://localhost:3000', { timeout: 120000 })
+      // cy.exec('curl --insecure https://localhost:3000', { timeout: 120000 })
     },
     { cacheAcrossSpecs: true }
   )


### PR DESCRIPTION
- made default login just use `oc whoami` by regardless of user - all someone needs to do is be logged into the hub already either via oc login / kubeconfig.
- updated local script to automatically set the BASE URL for cypress based on login
- updated credential path to skip directly there
- - commented out localhost for now but do we need to differentiate between local work (e.g. localhost) vs running against a remote cluster?