### PR TITLE
Update login and cred

### DIFF
--- a/cypress/config/config.ts
+++ b/cypress/config/config.ts
@@ -11,6 +11,17 @@ export function getTestEnv() {
   let envConfig: any = readFileSync(join(__dirname, 'options.yaml'))
   try {
     envConfig = load(envConfig)
+
+    // add a date to the cluster and cluster pool name to make it unique
+    let date = Date.now()
+    let providers = ['aws', 'azure', 'gcp', 'azgov']
+    console.log("Adding Date.now() suffix to all cluster names in options-*.yaml loaded: \n")
+    providers.forEach(provider => {
+      envConfig.options.clusters[provider].clusterName = envConfig.options.clusters[provider].clusterName + "-" + date
+      envConfig.options.clusterPools[provider].clusterPoolName = envConfig.options.clusterPools[provider].clusterPoolName + "-" + date
+      console.log(provider + " cluster name used in tests will be: " + envConfig.options.clusters[provider].clusterName + "\n" +
+      provider + " cluster pool name used in tests will be: " + envConfig.options.clusterPools[provider].clusterPoolName)
+    })
   } catch (e) {
     throw new Error(e)
   }

--- a/cypress/e2e/clusters/managedClusters/createClusters.cy.ts
+++ b/cypress/e2e/clusters/managedClusters/createClusters.cy.ts
@@ -31,9 +31,8 @@ describe(
   },
   function () {
     before(function () {
-      cy.clearOCMCookies()
       cy.login()
-      cy.setAPIToken()
+      cy.visit('multicloud/infrastructure/clusters/managed')
     })
 
     it(

--- a/cypress/e2e/credentials/addCredentials.cy.ts
+++ b/cypress/e2e/credentials/addCredentials.cy.ts
@@ -14,7 +14,7 @@ describe(
   function () {
     beforeEach(function () {
       cy.login()
-      cy.visit('/multicloud/infrastructure/')
+      cy.visit('/multicloud/infrastructure/credentials')
     })
 
     it(

--- a/cypress/scripts/local-setup.sh
+++ b/cypress/scripts/local-setup.sh
@@ -4,7 +4,8 @@ export BROWSER="chrome"
 export CYPRESS_OC_IDP=`oc whoami`
 export CYPRESS_OPTIONS_HUB_USER=`oc whoami`
 export CYPRESS_token=`oc whoami -t`
-export CYPRESS_CLUSTER_API_URL=`oc get infrastructure cluster -o jsonpath={.status.apiServerURL}`
+export CYPRESS_CLUSTER_API_URL=`oc whoami --show-server`
+export CYPRESS_BASE_URL=`oc whoami --show-console`
 # export CYPRESS_SPOKE_CLUSTER=""
 # export CYPRESS_CLC_OC_IDP=${CYPRESS_CLC_OC_IDP:-"clc-e2e-htpasswd"}
 # export CYPRESS_CLC_RBAC_PASS=${CYPRESS_CLC_RBAC_PASS:-"test-RBAC-4-e2e"}

--- a/cypress/support/action-utils/managedCluster.ts
+++ b/cypress/support/action-utils/managedCluster.ts
@@ -487,7 +487,7 @@ export const managedClustersMethods = {
 
   fillClusterDetails: (credentialName, clusterName, clusterSet, releaseImage, additionalLabels, enableSNO, fips) => {
     if (credentialName) {
-      cy.get('#connection-label').find('[aria-label="Options menu"]').click()
+      cy.get('#connection-label').find('input').click()
       cy.get('#connection-label').contains('li', credentialName).click()
     }
 

--- a/cypress/support/api-utils/automation.js
+++ b/cypress/support/api-utils/automation.js
@@ -5,8 +5,8 @@
 
 /// <reference types="cypress" />
 
-import * as constants from '../support/constants'
-import { genericFunctions } from '../support/genericFunctions'
+import * as constants from '../constants'
+import { genericFunctions } from '../genericFunctions'
 
 var headers = {
     "Content-Type": "application/json",

--- a/cypress/support/api-utils/cluster-api.js
+++ b/cypress/support/api-utils/cluster-api.js
@@ -4,8 +4,8 @@
  ****************************************************************************** */
 
 /// <reference types="cypress" />
-import * as constants from "../support/constants";
-import { genericFunctions } from '../support/genericFunctions'
+import * as constants from "../constants";
+import { genericFunctions } from '../genericFunctions'
 
 var headers = {
     "Content-Type": "application/json",

--- a/cypress/support/api-utils/clusterSet.js
+++ b/cypress/support/api-utils/clusterSet.js
@@ -5,7 +5,7 @@
 
 /// <reference types="cypress" />
 
-import * as constants from "../support/constants"
+import * as constants from "../constants"
 
 var headers = {
     "Content-Type": "application/json",

--- a/cypress/support/api-utils/hive.js
+++ b/cypress/support/api-utils/hive.js
@@ -4,8 +4,8 @@
  ****************************************************************************** */
 
 /// <reference types="cypress" />
-import * as constants from "../support/constants";
-import { genericFunctions } from '../support/genericFunctions'
+import * as constants from "../constants";
+import { genericFunctions } from '../genericFunctions'
 
 var headers = {
     "Content-Type": "application/json",

--- a/cypress/support/api-utils/kube.js
+++ b/cypress/support/api-utils/kube.js
@@ -5,8 +5,8 @@
 
 /// <reference types="cypress" />
 
-import * as constants from "../support/constants"
-import { genericFunctions } from '../support/genericFunctions'
+import * as constants from "../constants"
+import { genericFunctions } from '../genericFunctions'
 
 var headers = {
     "Content-Type": "application/json",

--- a/cypress/support/api-utils/metrics.js
+++ b/cypress/support/api-utils/metrics.js
@@ -5,7 +5,7 @@
 
 /// <reference types="cypress" />
 
-import * as constants from "../support/constants";
+import * as constants from "../constants";
 
 var headers = {
     "Content-Type": "application/json",

--- a/cypress/support/api-utils/rbac.js
+++ b/cypress/support/api-utils/rbac.js
@@ -5,7 +5,7 @@
 
 /// <reference types="cypress" />
 
-import * as constants from "../support/constants"
+import * as constants from "../constants"
 
 var headers = {
     "Content-Type": "application/json",

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -20,23 +20,12 @@ Cypress.Commands.add('login', (user: string = 'kube:admin', password?: string) =
   cy.session(
     user,
     () => {
-      if (process.env.NODE_ENV === 'production' || password) {
-        const baseUrl = Cypress.env('BASE_URL')
-        const username = user || Cypress.env('OPTIONS_HUB_USER')
-        const pass = password || Cypress.env('OPTIONS_HUB_PASSWORD')
-        cy.exec(`oc login ${baseUrl} -u ${username} -p ${pass}`).then(() => {
-          cy.exec('oc whoami -t').then((result) => {
-            cy.setCookie('acm-access-token-cookie', result.stdout)
-            Cypress.env({ token: result.stdout })
-          })
-        })
-      } else {
         // simple auth for local development environments
         cy.exec('oc whoami -t').then((result) => {
           cy.setCookie('acm-access-token-cookie', result.stdout)
+          cy.setCookie('openshift-session-token', result.stdout) // fails on MCE without this
         })
-      }
-      cy.exec('curl --insecure https://localhost:3000', { timeout: 120000 })
+      // cy.exec('curl --insecure https://localhost:3000', { timeout: 120000 })
     },
     { cacheAcrossSpecs: true }
   )


### PR DESCRIPTION
- made default login just use oc whoami by regardless of user - all someone needs to do is be logged into the hub already either via oc login / kubeconfig.
- updated local script to automatically set the BASE URL for cypress based on login
- updated credential path to skip directly there
- updated paths that for imports
- updated default visit location for cluster create
- fixed dropdown selector for creation wizard
- commented out localhost for now but do we need to differentiate between local work (e.g. localhost) vs running against a remote cluster?

Got aws create cluster through the wizard and kicked off:
<img width="1480" alt="image" src="https://user-images.githubusercontent.com/53154476/236411854-2295dc07-2a57-4e71-8e11-981a846f0bb1.png">
